### PR TITLE
Restructure portfolio layout and combine experience/education

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,8 +4,7 @@ import { LanguageProvider } from './contexts/LanguageContext'
 import Header from './components/Header'
 import Hero from './components/Hero'
 import About from './components/About'
-import Experience from './components/Experience'
-import Education from './components/Education'
+import ExperienceEducation from './components/ExperienceEducation'
 import SkillsGrid from './components/SkillsGrid'
 import Projects from './components/Projects'
 import Contact from './components/Contact'
@@ -22,8 +21,7 @@ function App() {
           <main>
             <Hero />
             <About />
-            <Experience />
-            <Education />
+            <ExperienceEducation />
             <SkillsGrid />
             <Projects />
             <Contact />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -21,9 +21,9 @@ function App() {
           <main>
             <Hero />
             <About />
-            <ExperienceEducation />
-            <SkillsGrid />
             <Projects />
+            <SkillsGrid />
+            <ExperienceEducation />
             <Contact />
           </main>
           <Footer />

--- a/src/components/Contact.jsx
+++ b/src/components/Contact.jsx
@@ -41,42 +41,6 @@ const Contact = () => {
           </motion.p>
         </motion.div>
 
-        {/* Info cards (email + location) */}
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-8 mb-8">
-          <motion.div initial="hidden" whileInView="visible" viewport={{ once: true }} variants={container}>
-            <Card className="card-hover h-full text-center">
-              <CardHeader>
-                <div className="flex flex-col items-center gap-4">
-                  <div className="w-20 h-20 rounded-full bg-primary/15 text-primary border border-primary/20 flex items-center justify-center">
-                    <Mail className="w-8 h-8" />
-                  </div>
-                  <CardTitle className="text-xl">{t('email')}</CardTitle>
-                </div>
-              </CardHeader>
-              <CardContent>
-                <a href="mailto:fbduarte.ic@gmail.com" className="text-lg font-medium text-muted-foreground hover:text-primary transition-colors">
-                  fbduarte.ic@gmail.com
-                </a>
-              </CardContent>
-            </Card>
-          </motion.div>
-
-          <motion.div initial="hidden" whileInView="visible" viewport={{ once: true }} variants={container}>
-            <Card className="card-hover h-full text-center">
-              <CardHeader>
-                <div className="flex flex-col items-center gap-4">
-                  <div className="w-20 h-20 rounded-full bg-primary/15 text-primary border border-primary/20 flex items-center justify-center">
-                    <MapPin className="w-8 h-8" />
-                  </div>
-                  <CardTitle className="text-xl">{t('location')}</CardTitle>
-                </div>
-              </CardHeader>
-              <CardContent>
-                <p className="text-lg font-medium text-muted-foreground">{t('locationValue')}</p>
-              </CardContent>
-            </Card>
-          </motion.div>
-        </div>
 
         {/* Social section */}
         <motion.div initial="hidden" whileInView="visible" viewport={{ once: true }} variants={container}>

--- a/src/components/ExperienceEducation.jsx
+++ b/src/components/ExperienceEducation.jsx
@@ -87,7 +87,7 @@ const ExperienceEducation = () => {
             <Card className="card-hover overflow-hidden hover:brightness-110 hover:scale-[1.01] flex flex-col items-center">
               <div className="flex flex-col">
                 <div className="w-full bg-gradient-to-br from-primary/20 to-primary/5 p-6 flex items-center justify-center">
-                  <img src="/assets/img/database.svg" alt="Universidade" className="w-full h-56 object-contain drop-shadow" />
+                  <img src="https://cdn.builder.io/api/v1/image/assets%2F257c6662cbff4e9d9eaaa0956ace7a59%2F4cb23e80ad634efca295fccdc0adfa5d?format=webp&width=800" alt="Universidade Federal do Maranhão" className="w-full h-56 object-cover drop-shadow" />
                 </div>
                 <div className="w-full">
                   <CardHeader className="pb-2">

--- a/src/components/ExperienceEducation.jsx
+++ b/src/components/ExperienceEducation.jsx
@@ -1,0 +1,214 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react'
+import { motion } from 'framer-motion'
+import { GraduationCap, Calendar, Briefcase, MapPin, Database, Code, CheckCircle2 } from 'lucide-react'
+import { Card, CardContent, CardHeader, CardTitle } from './ui/Card'
+import { useLanguage } from '../contexts/LanguageContext'
+
+const ExperienceEducation = () => {
+  const { t } = useLanguage()
+  const listRef = useRef(null)
+  const trackRef = useRef(null)
+  const [progress, setProgress] = useState(0)
+
+  const handleScroll = () => {
+    const el = listRef.current
+    if (!el) return
+    const max = el.scrollHeight - el.clientHeight
+    const ratio = max > 0 ? el.scrollTop / max : 0
+    setProgress(Math.min(1, Math.max(0, ratio)))
+  }
+
+  useEffect(() => {
+    const el = listRef.current
+    if (!el) return
+    handleScroll()
+    el.addEventListener('scroll', handleScroll)
+    return () => el.removeEventListener('scroll', handleScroll)
+  }, [])
+
+  const onTrackClick = (e) => {
+    const track = trackRef.current
+    const list = listRef.current
+    if (!track || !list) return
+    const rect = track.getBoundingClientRect()
+    const y = e.clientY - rect.top
+    const ratio = y / rect.height
+    const max = list.scrollHeight - list.clientHeight
+    list.scrollTo({ top: max * ratio, behavior: 'smooth' })
+  }
+
+  const experiences = useMemo(() => ([
+    {
+      id: 1,
+      icon: Database,
+      title: 'Bolsista - Análise de Dados',
+      company: 'JOVEM TECH - Pulse | Porto do Itaqui | Fapema',
+      period: 'Maio 2025 - Atual',
+      location: 'São Luís, Maranhão',
+      description: 'Atuo como bolsista com foco em Análise de Dados, desenvolvendo habilidades práticas em SQL (consultas simples e intermediárias), Excel, Python (Pandas e NumPy) e Power Bi.',
+      highlights: [
+        'Coleta, organização e análise de dados para apoiar decisões estratégicas',
+        'Transformação de dados em insights e criação de visualizações',
+        'Criação de pipelines de dados e estruturação de análises consistentes'
+      ],
+      skills: ['Python', 'Pandas', 'NumPy', 'Excel', 'Análise Estatística', 'Séries Temporais']
+    },
+    {
+      id: 2,
+      icon: Code,
+      title: 'Bolsista Back-end - Programa Trilhas',
+      company: 'Inova Maranhão - SECTI-MA',
+      period: '2024',
+      location: 'São Luís, Maranhão',
+      description: 'Especialização em desenvolvimento Back-end com Node.js através do programa Trilhas.',
+      highlights: [
+        'Desenvolvimento de APIs RESTful com Node.js e Express',
+        'Integração com bancos de dados',
+        'Autenticação e autorização',
+        'Práticas ágeis e versionamento de código'
+      ],
+      skills: ['Node.js', 'JavaScript', 'APIs REST', 'Banco de Dados']
+    }
+  ]), [])
+
+  const container = { hidden: { opacity: 0 }, visible: { opacity: 1, transition: { staggerChildren: 0.15 } } }
+  const item = { hidden: { opacity: 0, y: 24 }, visible: { opacity: 1, y: 0, transition: { duration: 0.5 } } }
+
+  return (
+    <section id="experience" className="section-padding">
+      <div className="container-max">
+        <motion.div initial="hidden" whileInView="visible" viewport={{ once: true, margin: '-100px' }} variants={container} className="text-center mb-12">
+          <motion.h2 variants={item} className="text-3xl md:text-4xl font-bold">{t('experienceEducationTitle')}</motion.h2>
+        </motion.div>
+
+        <div className="grid grid-cols-1 lg:grid-cols-12 gap-8">
+          {/* Left: Education Card */}
+          <motion.div variants={item} initial="hidden" whileInView="visible" viewport={{ once: true }} className="lg:col-span-5">
+            <Card className="card-hover overflow-hidden hover:brightness-110 hover:scale-[1.01]">
+              <div className="flex flex-col sm:flex-row">
+                <div className="sm:w-2/5 bg-gradient-to-br from-primary/20 to-primary/5 p-6 flex items-center justify-center">
+                  <img src="/assets/img/database.svg" alt="Universidade" className="w-32 h-32 object-contain drop-shadow" />
+                </div>
+                <div className="sm:w-3/5">
+                  <CardHeader className="pb-2">
+                    <div className="flex items-start gap-3">
+                      <div className="w-12 h-12 rounded-xl bg-primary/15 text-primary flex items-center justify-center">
+                        <GraduationCap className="w-6 h-6" />
+                      </div>
+                      <div className="flex-1">
+                        <CardTitle className="text-xl">Bacharelado em Engenharia da Computação</CardTitle>
+                        <div className="text-muted-foreground text-sm flex flex-wrap gap-3 mt-1">
+                          <span>Universidade Estadual do Maranhão (UEMA)</span>
+                          <span className="flex items-center gap-1"><Calendar className="w-4 h-4" />2022 - Em andamento</span>
+                        </div>
+                      </div>
+                    </div>
+                  </CardHeader>
+                  <CardContent className="pt-4">
+                    <h4 className="font-semibold mb-3">Conhecimentos e disciplinas:</h4>
+                    <ul className="space-y-2 text-muted-foreground">
+                      {[
+                        'Base sólida em matemática, estatística e programação',
+                        'Ênfase em análise de dados e engenharia de software',
+                        'Banco de Dados, Estruturas de Dados e Algoritmos'
+                      ].map((d) => (
+                        <li key={d} className="flex items-start gap-2">
+                          <CheckCircle2 className="w-4 h-4 text-primary mt-0.5 flex-shrink-0" />
+                          <span>{d}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </CardContent>
+                </div>
+              </div>
+            </Card>
+          </motion.div>
+
+          {/* Right: Experiences list with custom scroll indicator */}
+          <div className="lg:col-span-7 relative">
+            <div ref={listRef} className="space-y-6 lg:h-[640px] overflow-y-auto pr-6">
+              {experiences.map((exp) => {
+                const Icon = exp.icon
+                return (
+                  <motion.div key={exp.id} initial="hidden" whileInView="visible" viewport={{ once: true }} variants={item}>
+                    <Card className="card-hover relative overflow-hidden hover:brightness-110 hover:scale-[1.01]">
+                      <div className="absolute left-0 top-0 w-1 h-full bg-gradient-to-b from-primary to-primary/40" />
+                      <CardHeader>
+                        <div className="flex items-start gap-4">
+                          <div className="w-12 h-12 bg-gradient-to-br from-primary to-primary/80 rounded-xl flex items-center justify-center text-primary-foreground shadow-lg">
+                            <Icon className="w-6 h-6" />
+                          </div>
+                          <div className="flex-1">
+                            <CardTitle className="text-xl mb-1">{exp.title}</CardTitle>
+                            <div className="space-y-1">
+                              <div className="flex items-center gap-2 text-muted-foreground text-sm">
+                                <Briefcase className="w-4 h-4" />
+                                <span className="font-medium">{exp.company}</span>
+                              </div>
+                              <div className="flex flex-wrap items-center gap-4 text-sm text-muted-foreground">
+                                <span className="flex items-center gap-1"><Calendar className="w-4 h-4" />{exp.period}</span>
+                                <span className="flex items-center gap-1"><MapPin className="w-4 h-4" />{exp.location}</span>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </CardHeader>
+
+                      <CardContent className="space-y-5">
+                        <p className="text-muted-foreground leading-relaxed">{exp.description}</p>
+                        <div>
+                          <h4 className="font-semibold mb-2">Atividades:</h4>
+                          <ul className="space-y-2">
+                            {exp.highlights.map((h) => (
+                              <li key={h} className="flex items-start gap-2 text-muted-foreground">
+                                <span className="w-1.5 h-1.5 bg-primary rounded-full mt-2" />
+                                <span>{h}</span>
+                              </li>
+                            ))}
+                          </ul>
+                        </div>
+                        <div>
+                          <h4 className="font-semibold mb-2">Tecnologias:</h4>
+                          <div className="flex flex-wrap gap-2">
+                            {exp.skills.map((s, i) => (
+                              <motion.span
+                                key={s}
+                                initial={{ opacity: 0, scale: 0.9 }}
+                                whileInView={{ opacity: 1, scale: 1 }}
+                                viewport={{ once: true }}
+                                transition={{ delay: i * 0.05 }}
+                                className="px-3 py-1 bg-primary/10 text-primary text-xs font-medium rounded-full border border-primary/20"
+                              >
+                                {s}
+                              </motion.span>
+                            ))}
+                          </div>
+                        </div>
+                      </CardContent>
+                    </Card>
+                  </motion.div>
+                )
+              })}
+            </div>
+
+            {/* Custom scroll indicator */}
+            <div className="hidden lg:block absolute right-0 top-0 bottom-0 w-4 flex items-center">
+              <div
+                ref={trackRef}
+                onClick={onTrackClick}
+                className="relative mx-auto w-1 h-[calc(100%-2rem)] rounded-full bg-border cursor-pointer"
+              >
+                <div
+                  className="absolute left-0 top-0 w-1 rounded-full bg-gradient-to-b from-primary to-primary/60"
+                  style={{ height: `${Math.max(8, progress * 100)}%` }}
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+export default ExperienceEducation

--- a/src/components/ExperienceEducation.jsx
+++ b/src/components/ExperienceEducation.jsx
@@ -87,7 +87,7 @@ const ExperienceEducation = () => {
             <Card className="card-hover overflow-hidden hover:brightness-110 hover:scale-[1.01] flex flex-col items-center">
               <div className="flex flex-col">
                 <div className="w-full bg-gradient-to-br from-primary/20 to-primary/5 p-6 flex items-center justify-center">
-                  <img src="https://cdn.builder.io/api/v1/image/assets%2F257c6662cbff4e9d9eaaa0956ace7a59%2F4cb23e80ad634efca295fccdc0adfa5d?format=webp&width=800" alt="Universidade Federal do Maranhão" className="w-full h-56 object-cover drop-shadow" />
+                  <img src="https://cdn.builder.io/api/v1/image/assets%2F257c6662cbff4e9d9eaaa0956ace7a59%2F4cb23e80ad634efca295fccdc0adfa5d?format=webp&width=800" alt="Universidade Federal do Maranhão" className="w-full h-56 md:h-64 lg:h-72 object-cover rounded-t-lg" />
                 </div>
                 <div className="w-full">
                   <CardHeader className="pb-2">

--- a/src/components/ExperienceEducation.jsx
+++ b/src/components/ExperienceEducation.jsx
@@ -96,10 +96,10 @@ const ExperienceEducation = () => {
                         <GraduationCap className="w-6 h-6" />
                       </div>
                       <div className="flex-1">
-                        <CardTitle className="text-xl">Bacharelado em Engenharia da Computação</CardTitle>
+                        <CardTitle className="text-xl">Bacharelado Interdisciplinar em Ciência e Tecnologia</CardTitle>
                         <div className="text-muted-foreground text-sm flex flex-wrap gap-3 mt-1">
-                          <span>Universidade Estadual do Maranhão (UEMA)</span>
-                          <span className="flex items-center gap-1"><Calendar className="w-4 h-4" />2022 - Em andamento</span>
+                          <span>Universidade Federal do Maranhão (UFMA)</span>
+                          <span className="flex items-center gap-1"><Calendar className="w-4 h-4" />2023 - Presente | Cursando</span>
                         </div>
                       </div>
                     </div>
@@ -108,9 +108,12 @@ const ExperienceEducation = () => {
                     <h4 className="font-semibold mb-3">Conhecimentos e disciplinas:</h4>
                     <ul className="space-y-2 text-muted-foreground">
                       {[
-                        'Base sólida em matemática, estatística e programação',
-                        'Ênfase em análise de dados e engenharia de software',
-                        'Banco de Dados, Estruturas de Dados e Algoritmos'
+                        'Ciência de Dados: Análise estatística, Visualização de dados e Machine Learning',
+                        'Algoritmos e Programação: Fundamentos da Computação e Estruturas de Dados',
+                        'Matemática Aplicada: Álgebra Linear, Cálculo, Probabilidade e Estatística',
+                        'Engenharia de Software: Metodologias ágeis e arquitetura de sistemas',
+                        'Administração: Gestão de projetos, empreendedorismo e inovação',
+                        'Física e Química: Fundamentos científicos para aplicações tecnológicas'
                       ].map((d) => (
                         <li key={d} className="flex items-start gap-2">
                           <CheckCircle2 className="w-4 h-4 text-primary mt-0.5 flex-shrink-0" />

--- a/src/components/ExperienceEducation.jsx
+++ b/src/components/ExperienceEducation.jsx
@@ -84,12 +84,12 @@ const ExperienceEducation = () => {
         <div className="grid grid-cols-1 lg:grid-cols-12 gap-8">
           {/* Left: Education Card */}
           <motion.div variants={item} initial="hidden" whileInView="visible" viewport={{ once: true }} className="lg:col-span-5">
-            <Card className="card-hover overflow-hidden hover:brightness-110 hover:scale-[1.01]">
-              <div className="flex flex-col sm:flex-row">
-                <div className="sm:w-2/5 bg-gradient-to-br from-primary/20 to-primary/5 p-6 flex items-center justify-center">
-                  <img src="/assets/img/database.svg" alt="Universidade" className="w-32 h-32 object-contain drop-shadow" />
+            <Card className="card-hover overflow-hidden hover:brightness-110 hover:scale-[1.01] flex flex-col items-center">
+              <div className="flex flex-col">
+                <div className="w-full bg-gradient-to-br from-primary/20 to-primary/5 p-6 flex items-center justify-center">
+                  <img src="/assets/img/database.svg" alt="Universidade" className="w-full h-56 object-contain drop-shadow" />
                 </div>
-                <div className="sm:w-3/5">
+                <div className="w-full">
                   <CardHeader className="pb-2">
                     <div className="flex items-start gap-3">
                       <div className="w-12 h-12 rounded-xl bg-primary/15 text-primary flex items-center justify-center">

--- a/src/components/ExperienceEducation.jsx
+++ b/src/components/ExperienceEducation.jsx
@@ -128,8 +128,8 @@ const ExperienceEducation = () => {
           </motion.div>
 
           {/* Right: Experiences list with custom scroll indicator */}
-          <div className="lg:col-span-7 relative">
-            <div ref={listRef} className="space-y-6 lg:h-[640px] overflow-y-auto pr-6">
+          <div className="lg:col-span-7 relative pb-[9px]">
+            <div ref={listRef} className="space-y-6 lg:h-[826px] overflow-y-auto pr-6">
               {experiences.map((exp) => {
                 const Icon = exp.icon
                 return (

--- a/src/components/ExperienceEducation.jsx
+++ b/src/components/ExperienceEducation.jsx
@@ -51,7 +51,7 @@ const ExperienceEducation = () => {
         'Transformação de dados em insights e criação de visualizações',
         'Criação de pipelines de dados e estruturação de análises consistentes'
       ],
-      skills: ['Python', 'Pandas', 'NumPy', 'Excel', 'Análise Estatística', 'Séries Temporais']
+      skills: ['Python', 'Pandas', 'NumPy', 'Excel', 'Análise Estat��stica', 'Séries Temporais']
     },
     {
       id: 2,
@@ -86,9 +86,10 @@ const ExperienceEducation = () => {
           <motion.div variants={item} initial="hidden" whileInView="visible" viewport={{ once: true }} className="lg:col-span-5">
             <Card className="card-hover overflow-hidden hover:brightness-110 hover:scale-[1.01] flex flex-col items-center">
               <div className="flex flex-col">
-                <div className="w-full bg-gradient-to-br from-primary/20 to-primary/5 p-6 flex items-center justify-center">
+                <div className="hidden">
                   <img src="https://cdn.builder.io/api/v1/image/assets%2F257c6662cbff4e9d9eaaa0956ace7a59%2F4cb23e80ad634efca295fccdc0adfa5d?format=webp&width=800" alt="Universidade Federal do Maranhão" className="w-full h-56 md:h-64 lg:h-72 object-cover rounded-t-lg" />
                 </div>
+                <img src="https://cdn.builder.io/api/v1/image/assets%2F257c6662cbff4e9d9eaaa0956ace7a59%2F4cb23e80ad634efca295fccdc0adfa5d?format=webp&width=800" alt="Universidade Federal do Maranhão" className="w-full h-56 md:h-64 lg:h-72 object-cover rounded-t-lg" />
                 <div className="w-full">
                   <CardHeader className="pb-2">
                     <div className="flex items-start gap-3">
@@ -104,7 +105,7 @@ const ExperienceEducation = () => {
                       </div>
                     </div>
                   </CardHeader>
-                  <CardContent className="pt-4">
+                  <CardContent className="pt-4 px-6 pb-6">
                     <h4 className="font-semibold mb-3">Conhecimentos e disciplinas:</h4>
                     <ul className="space-y-2 text-muted-foreground">
                       {[

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -23,9 +23,9 @@ const Header = () => {
   const navItems = [
     { href: '#home', label: t('home') },
     { href: '#about', label: t('about') },
-    { href: '#experience', label: t('experience') },
-    { href: '#skills', label: t('skills') },
     { href: '#projects', label: t('projects') },
+    { href: '#skills', label: t('skills') },
+    { href: '#experience', label: t('experience') },
     { href: '#contact', label: t('contact') },
   ]
 

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -23,7 +23,6 @@ const Header = () => {
   const navItems = [
     { href: '#home', label: t('home') },
     { href: '#about', label: t('about') },
-    { href: '#education', label: t('education') },
     { href: '#experience', label: t('experience') },
     { href: '#skills', label: t('skills') },
     { href: '#projects', label: t('projects') },

--- a/src/components/Projects.jsx
+++ b/src/components/Projects.jsx
@@ -34,7 +34,7 @@ const Projects = () => {
       id: 2,
       title: 'Análise de Salários na Área de Dados - Imersão Alura',
       shortDescription: 'Análise detalhada dos salários em Data Science, com recortes por senioridade, contrato, país, remoto e variações anuais; inclui dashboard interativo.',
-      fullDescription: 'Estudo abrangente da estrutura salarial na área de dados. Explorei níveis de experiência, tipos de vínculo e cargos, normalizei remunerações, comparei remuneração por país e modalidade de trabalho (remoto/hib/onsite) e observei tendências temporais. O projeto também inclui um dashboard no Streamlit para exploração interativa e geração r��pida de insights por recrutadores e profissionais.',
+      fullDescription: 'Estudo abrangente da estrutura salarial na área de dados. Explorei níveis de experiência, tipos de vínculo e cargos, normalizei remunerações, comparei remuneração por país e modalidade de trabalho (remoto/hib/onsite) e observei tendências temporais. O projeto também inclui um dashboard no Streamlit para exploração interativa e geração rápida de insights por recrutadores e profissionais.',
       image: '/assets/img/Análsie dos setores.jpg',
       category: 'data-analysis',
       technologies: ['Python', 'Pandas', 'Matplotlib', 'NumPy', 'Streamlit'],
@@ -255,11 +255,9 @@ const Projects = () => {
           viewport={{ once: true }}
           className="text-center mt-12"
         >
-          <Button asChild variant="outline" size="lg">
-            <a href="projetos.html">
-              {t('viewAllProjects')}
-              <ExternalLink className="w-4 h-4" />
-            </a>
+          <Button variant="outline" size="lg" onClick={() => { window.location.href = 'projetos.html' }}>
+            {t('viewAllProjects')}
+            <ExternalLink className="w-4 h-4" />
           </Button>
         </motion.div>
       </div>

--- a/src/components/Projects.jsx
+++ b/src/components/Projects.jsx
@@ -4,6 +4,7 @@ import { ExternalLink, Github, Eye, X, Filter } from 'lucide-react'
 import { Button } from './ui/Button'
 import { Card, CardContent, CardHeader, CardTitle } from './ui/Card'
 import { useLanguage } from '../contexts/LanguageContext'
+import StarField from './StarField'
 
 const Projects = () => {
   const { t } = useLanguage()
@@ -102,8 +103,11 @@ const Projects = () => {
   }
 
   return (
-    <section id="projects" className="section-padding bg-card/30">
-      <div className="container-max">
+    <section id="projects" className="section-padding relative overflow-hidden">
+      <div className="absolute inset-0 bg-gradient-to-br from-primary/10 via-transparent to-accent/10" />
+      <div className="absolute inset-0 bg-grid-pattern opacity-10" />
+      <StarField count={100} />
+      <div className="container-max relative z-10">
         <motion.div
           initial="hidden"
           whileInView="visible"

--- a/src/components/Projects.jsx
+++ b/src/components/Projects.jsx
@@ -34,7 +34,7 @@ const Projects = () => {
       id: 2,
       title: 'Análise de Salários na Área de Dados - Imersão Alura',
       shortDescription: 'Análise detalhada dos salários em Data Science, com recortes por senioridade, contrato, país, remoto e variações anuais; inclui dashboard interativo.',
-      fullDescription: 'Estudo abrangente da estrutura salarial na área de dados. Explorei níveis de experiência, tipos de vínculo e cargos, normalizei remunerações, comparei remuneração por país e modalidade de trabalho (remoto/hib/onsite) e observei tendências temporais. O projeto também inclui um dashboard no Streamlit para exploração interativa e geração rápida de insights por recrutadores e profissionais.',
+      fullDescription: 'Estudo abrangente da estrutura salarial na área de dados. Explorei níveis de experiência, tipos de vínculo e cargos, normalizei remunerações, comparei remuneração por país e modalidade de trabalho (remoto/hib/onsite) e observei tendências temporais. O projeto também inclui um dashboard no Streamlit para exploração interativa e geração r��pida de insights por recrutadores e profissionais.',
       image: '/assets/img/Análsie dos setores.jpg',
       category: 'data-analysis',
       technologies: ['Python', 'Pandas', 'Matplotlib', 'NumPy', 'Streamlit'],
@@ -255,9 +255,11 @@ const Projects = () => {
           viewport={{ once: true }}
           className="text-center mt-12"
         >
-          <Button variant="outline" size="lg">
-            {t('viewAllProjects')}
-            <ExternalLink className="w-4 h-4" />
+          <Button asChild variant="outline" size="lg">
+            <a href="projetos.html">
+              {t('viewAllProjects')}
+              <ExternalLink className="w-4 h-4" />
+            </a>
           </Button>
         </motion.div>
       </div>

--- a/src/contexts/LanguageContext.jsx
+++ b/src/contexts/LanguageContext.jsx
@@ -38,7 +38,8 @@ const translations = {
     dataVisualization: 'Visualização de Dados',
     appliedStatistics: 'Estatística Aplicada',
     educationTitle: 'Formação Acadêmica',
-    
+    experienceEducationTitle: 'Experiência e Formação',
+
     // Experience Section
     experienceTitle: 'Experiência Profissional',
     
@@ -101,7 +102,8 @@ const translations = {
     dataVisualization: 'Data Visualization',
     appliedStatistics: 'Applied Statistics',
     educationTitle: 'Education',
-    
+    experienceEducationTitle: 'Experience & Education',
+
     // Experience Section
     experienceTitle: 'Professional Experience',
     


### PR DESCRIPTION
## Purpose

The user requested a complete restructuring of the portfolio website to match a specific layout order: Home (Hero) → About → Projects → Skills → Experience & Education → Contact. They also wanted the projects section to have a starry background similar to the main page, proper formatting of the experience/education section with rounded image borders, and a functional "view all projects" button.

## Code changes

- **Layout restructuring**: Reordered sections in `App.jsx` to match the requested structure (Projects moved before Skills, Experience and Education combined)
- **Component consolidation**: Merged separate `Experience` and `Education` components into a single `ExperienceEducation` component with improved layout and styling
- **Projects enhancement**: Added `StarField` component and gradient backgrounds to create the requested starry effect
- **Navigation updates**: Updated header navigation to reflect the new section order
- **Contact simplification**: Removed email and location info cards from the contact section
- **Functionality improvement**: Made the "view all projects" button functional by adding click handler to navigate to `projetos.html`
- **Visual improvements**: Enhanced the education section with proper image display, rounded borders, and better card layout
- **Translation updates**: Added new translation key for the combined "Experience & Education" section title

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/aa05ae2c49314ac3b62cfb4a074c9095/stellar-landing)

👀 [Preview Link](https://aa05ae2c49314ac3b62cfb4a074c9095-stellar-landing.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>aa05ae2c49314ac3b62cfb4a074c9095</projectId>-->
<!--<branchName>stellar-landing</branchName>-->