### PR TITLE
Fix "Ver mais projetos" button navigation path

### DIFF
--- a/src/components/Projects.jsx
+++ b/src/components/Projects.jsx
@@ -277,7 +277,7 @@ const Projects = ({ showViewAllButton = true, showTopBackButton = false }) => {
             viewport={{ once: true }}
             className="text-center mt-12"
           >
-            <Button variant="outline" size="lg" onClick={() => { window.location.href = 'projetos.html' }}>
+            <Button variant="outline" size="lg" onClick={() => { window.location.href = '/projetos.html' }}>
               {t('viewAllProjects')}
               <ExternalLink className="w-4 h-4" />
             </Button>


### PR DESCRIPTION
## Purpose
The user reported that the "Ver mais projetos" (View more projects) button was not working properly on Vercel deployment. This fix addresses the navigation issue by correcting the URL path.

## Code changes
- Updated the onClick handler for the "View All Projects" button in `Projects.jsx`
- Changed the navigation path from `'projetos.html'` to `'/projetos.html'` (added leading slash)
- This ensures proper absolute path navigation that works correctly in deployed environments like Vercel

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4`

🔗 [Edit in Builder.io](https://builder.io/app/projects/546d60a4cd664ddd9eea05bf13f97ae5/nova-zone)

👀 [Preview Link](https://546d60a4cd664ddd9eea05bf13f97ae5-nova-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>546d60a4cd664ddd9eea05bf13f97ae5</projectId>-->
<!--<branchName>nova-zone</branchName>-->